### PR TITLE
Ticket2633 mk3 chopper speed crash

### DIFF
--- a/Mk3BridgeLib/Mk3BridgeLib.cpp
+++ b/Mk3BridgeLib/Mk3BridgeLib.cpp
@@ -591,9 +591,8 @@ namespace Mk3BridgeLib
 		{
 			return;
 		}
-
 		IntPtr p = Marshal::StringToHGlobalAnsi(str);
-		strcpy(result, static_cast<char*>(p.ToPointer()));
+		strncpy_s(result, size, static_cast<char*>(p.ToPointer()), size-1);
 		Marshal::FreeHGlobal(p);
 
 		return;

--- a/Mk3BridgeLib/Mk3BridgeLib.cpp
+++ b/Mk3BridgeLib/Mk3BridgeLib.cpp
@@ -585,17 +585,9 @@ namespace Mk3BridgeLib
 	void Mk3Chopper::StringToCharArray(String^ str, char* result, int size)
 	{
 		using namespace Runtime::InteropServices;
-
-		// If size is less than 50 don't bother
-		if (size < 50)
-		{
-			return;
-		}
 		IntPtr p = Marshal::StringToHGlobalAnsi(str);
 		strncpy_s(result, size, static_cast<char*>(p.ToPointer()), size-1);
 		Marshal::FreeHGlobal(p);
-
-		return;
 	}
 }
 


### PR DESCRIPTION
# Description

The current Mk3 chopper crashes on encountering error code 21. I tracked the issue to an overflow when resolving the error code to a string. I've switched the string copy over to using a safe copy up to a maximum size. There's a corresponding change in the IOC to increase the buffer size to account for known errors.

I removed the `if` because it's never used in our context and just increases code complexity.

# Ticket

https://github.com/ISISComputingGroup/IBEX/issues/2633

# Acceptance criteria

To get error messages emitted by the Mock Chopper, do the following:

- Change the error-code to something positive in MockChopper.cs. For instance `PutNominalPhaseErrorWindow`
- Change the error message in `ResolveErrorCode` in `MockChopper.cs`
- Build the chopper support module and IOC
- Run the IOC in DevSim mode which, with the IOC PR, will instruct it to use the mock chopper
- Perform the operation you set the error code for (e.g. Change the phase error window)
- Note that the IOC returns the error message you set above

To verify the ticket, I expect the following:

- [x] On `master` change the error code and message to something longer than 50 characters (e.g. the error reported in the ticket). Compile and run the IOC (you'll need to set it to use the mock chopper manually without the PRs). When you do the associated operation, it should cause the IOC to crash.

Repeat the operation with the PRs. The buffer size is now 100 characters:

- [x] The IOC does not crash for an error message of fewer than 100 characters. The full error message is reported.
- [x] The IOC does not crash for an error message of greater than 100 characters. The first 99 characters are reported (100th character reserved for null terminator).