### PR TITLE
Do not reinitalise remoting each time. Only create proxy when needed

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,27 @@
+# Set the default behavior, in case people don't have core.autocrlf set.
+* text=auto
+
+# Explicitly declare text files you want to always be normalized and converted
+# to native line endings on checkout.
+*.c text
+*.cpp text
+*.h text
+*.hpp text
+*.java text
+*.sh text eol=lf
+*.bat text
+*.cmd text
+*.db text
+*.dbd text
+*.template text
+*.substitutions text
+
+# Declare files that will always have CRLF line endings on checkout.
+*.sln text eol=crlf
+
+# Denote all files that are truly binary and should not be modified.
+*.png binary
+*.jpg binary
+*.class binary
+*.vi binary
+

--- a/Mk3BridgeLib/Mk3BridgeLib.cpp
+++ b/Mk3BridgeLib/Mk3BridgeLib.cpp
@@ -9,7 +9,13 @@ using namespace System::Collections::Generic;
 
 namespace Mk3BridgeLib
 {
-
+    /** Initialise the chopper framework and connect to it.
+     *  NB Although it appears you can change the config file here for each initialise because of implementation details
+     *  you can't it will use the first one you set.
+     *  @param configFile configuration file for the .net remoting
+     *  @param useMock if true use the mocked version of the chopper which simulates connecting to a real chopper; False for
+     *       real connection
+    */
 	int Mk3Chopper::Initialise(char* configFile, bool useMock)
 	{
 		int errCode = 0;

--- a/Mk3BridgeLib/Mk3BridgeLib.cpp
+++ b/Mk3BridgeLib/Mk3BridgeLib.cpp
@@ -14,16 +14,18 @@ namespace Mk3BridgeLib
 	{
 		int errCode = 0;
 
-		if (useMock)
-		{
-			chopper = gcnew Mk3Wrapper::MockChopper(gcnew System::String(configFile));
-			errCode = chopper->Initialise();
+		if (chopper == nullptr) {
+			if (useMock)
+			{
+				chopper = gcnew Mk3Wrapper::MockChopper(gcnew System::String(configFile));
+			}
+			else
+			{
+				chopper = gcnew Mk3Wrapper::Chopper(gcnew System::String(configFile));
+			}
 		}
-		else
-		{
-			chopper = gcnew Mk3Wrapper::Chopper(gcnew System::String(configFile));
-			errCode = chopper->Initialise();
-		}
+
+		errCode = chopper->Initialise();
 
 		return errCode;
 	}

--- a/Mk3Wrapper/Chopper.cs
+++ b/Mk3Wrapper/Chopper.cs
@@ -9,31 +9,53 @@ namespace Mk3Wrapper
     public class Chopper : IChopper
     {
         string configFile = "";
-        MK3ChopperSkeleton.IBeamLine _beamline = null;
-        MK3ChopperSkeleton.RemotingHelper _helper;
+        static MK3ChopperSkeleton.IBeamLine _beamline = null;
+		static bool remotingSetConfigured = false;
 
         public Chopper(string configFile)
         {
             this.configFile = configFile;
+
         }
 
+        /**
+         * Initialise the connection to the chopper server.
+         *  - intiallise the remoting based on the config file, this can be done without a remote machine
+         *  - create a proxy and make sure it connects. If there is already a working proxy don't create a second one.
+         *  - if proxy can not connect then blank it and error
+         *  
+         * Returns:
+         *  0 everything was ok
+         *  -5 configuration file does not exist
+         *  -6 proxy can not be created or can not connect to the sever
+         */
         public int Initialise()
         {
-            // Does file exist?
-            if (!File.Exists(this.configFile))
-            {
-                return -5;
-            }
-
             try
             {
-                RemotingConfiguration.Configure(configFile, false);
-
-                _helper = new MK3ChopperSkeleton.RemotingHelper();
-                _beamline = (MK3ChopperSkeleton.IBeamLine)MK3ChopperSkeleton.RemotingHelper.CreateProxy();
+				if (!remotingSetConfigured) {
+                    // Does remoting configuration file exist
+                    if (!File.Exists(this.configFile))
+                    {
+                        return -5;
+                    }
+					RemotingConfiguration.Configure(configFile, false);
+					remotingSetConfigured = true;
+					
+				}
+                // setup proxy
+				if (_beamline == null) {
+					_beamline = (MK3ChopperSkeleton.IBeamLine)MK3ChopperSkeleton.RemotingHelper.CreateProxy(typeof(MK3ChopperSkeleton.IBeamLine));
+					if (!RemotingServices.IsTransparentProxy(_beamline))
+					{
+						throw new RemotingException("Proxy To Server Could Not Be Established");
+					}
+				}
+                _beamline.ServerHealthy();  // Check that server is ok
             }
             catch
             {
+				_beamline = null;
                 return -6;
             }
 

--- a/Mk3Wrapper/Chopper.cs
+++ b/Mk3Wrapper/Chopper.cs
@@ -9,8 +9,8 @@ namespace Mk3Wrapper
     public class Chopper : IChopper
     {
         string configFile = "";
-        static MK3ChopperSkeleton.IBeamLine _beamline = null;
-		static bool remotingSetConfigured = false;
+        MK3ChopperSkeleton.IBeamLine _beamline = null;
+        bool remotingSetConfigured = false;
 
         public Chopper(string configFile)
         {
@@ -33,29 +33,29 @@ namespace Mk3Wrapper
         {
             try
             {
-				if (!remotingSetConfigured) {
+                if (!remotingSetConfigured) {
                     // Does remoting configuration file exist
                     if (!File.Exists(this.configFile))
                     {
                         return -5;
                     }
-					RemotingConfiguration.Configure(configFile, false);
-					remotingSetConfigured = true;
-					
-				}
+                    RemotingConfiguration.Configure(configFile, false);
+                    remotingSetConfigured = true;
+                    
+                }
                 // setup proxy
-				if (_beamline == null) {
-					_beamline = (MK3ChopperSkeleton.IBeamLine)MK3ChopperSkeleton.RemotingHelper.CreateProxy(typeof(MK3ChopperSkeleton.IBeamLine));
-					if (!RemotingServices.IsTransparentProxy(_beamline))
-					{
-						throw new RemotingException("Proxy To Server Could Not Be Established");
-					}
-				}
+                if (_beamline == null) {
+                    _beamline = (MK3ChopperSkeleton.IBeamLine)MK3ChopperSkeleton.RemotingHelper.CreateProxy(typeof(MK3ChopperSkeleton.IBeamLine));
+                    if (!RemotingServices.IsTransparentProxy(_beamline))
+                    {
+                        throw new RemotingException("Proxy To Server Could Not Be Established");
+                    }
+                }
                 _beamline.ServerHealthy();  // Check that server is ok
             }
             catch
             {
-				_beamline = null;
+                _beamline = null;
                 return -6;
             }
 

--- a/unbuild.bat
+++ b/unbuild.bat
@@ -18,6 +18,9 @@ if /I "%EPICS_HOST_ARCH%" == "win32-x86" (
 
 if %ERRORLEVEL% neq 0 goto PROBLEM
 
+rmdir /S /Q bin\%EPICS_HOST_ARCH%
+rmdir /S /Q lib\%EPICS_HOST_ARCH%
+
 GOTO :EOF
 
 :PROBLEM


### PR DESCRIPTION
To fix ticket: https://github.com/ISISComputingGroup/IBEX/issues/3103

Test no memory leak (it may need 5 minutes to stabilise memory):

1. Can not connect to machine
1. Can not connect to server
1. Has been connected but can not connect any more
1. Is connected.

Connection is changed using the `C:\LabVIEW Modules\Drivers\ISIS MK3 Disc Chopper\MK3_Chopper.config`